### PR TITLE
schien noch ohne «permissive license», noch eines der angetroffenen Atome 

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2019 example example
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
Dem Vortrag fehlt unter anderem eine Lizenz (wie etwa https://nbn-resolving.org/urn:nbn:de:bsz:14-qucosa2-77350).  Ob GPLv2 oder eines der Atome CC-CA et cetera von der Gegenüberstellung von Literaturverwaltungen besser «passt» als MIT?  Wie auf 

https://www.youtube.com/watch?v=9kGrKBOytYM

nach etwas mehr als 30 mn zu hören kann _Dokumentation_ auch mit anderem Schlüssel als das / als ein Software-Program versehen werden.